### PR TITLE
Kept and abstracted support for server on command line side only

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+module.exports = function(app, opts) {
+  var reload = require('./lib/reload')
+
+  return reload(app, opts)
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = function(app, opts) {
+module.exports = function (app, opts) {
   var reload = require('./lib/reload')
 
   return reload(app, opts)

--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -17,6 +17,11 @@ var runFile = argv._[4]
 var startPage = argv._[5]
 var verbose = (argv._[6] === 'true')
 
+var reloadOpts = {
+  port: port,
+  verbose: verbose
+}
+
 var router = express.Router()
 
 app.set('port', port)
@@ -51,7 +56,7 @@ app.use(express.static(dir)) // Should cache static assets.
 var server = http.createServer(app)
 
 // Reload call and configurations.
-reload(server, app, verbose)
+reload(app, reloadOpts, server)
 
 server.listen(app.get('port'), function () {
   if (!fs.existsSync(runFile)) {

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -1,10 +1,4 @@
-/*
- * Posible opts
- * port: A port to run the reload websocket on (as a number). (Optional) (Default: `8080`)
- * route: The route reload will create for the script file. (Optional) (Default `reload/reload.js`)
- * verbose: Will show logging on the server and client side. (Optional) (Default: `false`)
- */
-function reload (app, opts) {
+module.exports = function reload(app, opts, server) {
   // Requires
   var path = require('path')
   var fs = require('fs')
@@ -75,6 +69,11 @@ function reload (app, opts) {
         socketPortSpecified = port
         httpServerOrPort = port
       }
+
+      if (server) {
+        socketPortSpecified = null;
+        httpServerOrPort = server;
+      }
     }
   } else {
     throw new TypeError('Lack of/invalid arguments provided to reload', 'reload.js', 7)
@@ -84,10 +83,7 @@ function reload (app, opts) {
   if (verboseLogging) {
     reloadCode = reloadCode.replace('verboseLogging = false', 'verboseLogging = true')
   }
-
-  if (socketPortSpecified) {
-    reloadCode = reloadCode.replace('window.location.origin.replace()', 'window.location.origin.replace(/(^http(s?):\\/\\/)(.*:)(.*)/,' + (socketPortSpecified ? '\'ws$2://$3' + socketPortSpecified : 'ws$2://$3$4') + '\')')
-  }
+  reloadCode = reloadCode.replace('window.location.origin.replace()', 'window.location.origin.replace(/(^http(s?):\\/\\/)(.*:)(.*)/,' + (socketPortSpecified ? '\'ws$2://$3' + socketPortSpecified : '\'ws$2://$3$4') + '\')')
 
   expressApp.get(route, function (req, res) {
     res.type('text/javascript')
@@ -135,5 +131,3 @@ function reload (app, opts) {
     'sendMessage': sendMessage
   }
 }
-
-module.exports = reload

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -1,4 +1,4 @@
-module.exports = function reload(app, opts, server) {
+module.exports = function reload (app, opts, server) {
   // Requires
   var path = require('path')
   var fs = require('fs')
@@ -71,8 +71,8 @@ module.exports = function reload(app, opts, server) {
       }
 
       if (server) {
-        socketPortSpecified = null;
-        httpServerOrPort = server;
+        socketPortSpecified = null
+        httpServerOrPort = server
       }
     }
   } else {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "standard": "^10.0.2"
   },
-  "main": "./lib/reload.js",
+  "main": "./index.js",
   "scripts": {
     "test": "npm run standard",
     "standard": "standard **/*.js bin/**/*"


### PR DESCRIPTION
Abstracted reload call into an index file, to hide the optional third parameter being used private in the `reload` file. The third argument server is reserved **only** for the command line use.

Related to #102