### PR TITLE
Allow for hidden port 80

### DIFF
--- a/lib/reload-client.js
+++ b/lib/reload-client.js
@@ -1,6 +1,10 @@
 (function refresh () {
   var verboseLogging = false
-  var socketUrl = window.location.origin.replace() // This is dynamically populated by the reload.js file before it is sent to the browser
+  var socketUrl = window.location.origin
+  if (!window.location.origin.match(/:[0-9]+/)) {
+    socketUrl = window.location.origin + ':80'
+  }
+  socketUrl = socketUrl.replace() // This is dynamically populated by the reload.js file before it is sent to the browser
   var socket
 
   if (verboseLogging) {

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -83,7 +83,7 @@ module.exports = function reload (app, opts, server) {
   if (verboseLogging) {
     reloadCode = reloadCode.replace('verboseLogging = false', 'verboseLogging = true')
   }
-  reloadCode = reloadCode.replace('window.location.origin.replace()', 'window.location.origin.replace(/(^http(s?):\\/\\/)(.*:)(.*)/,' + (socketPortSpecified ? '\'ws$2://$3' + socketPortSpecified : '\'ws$2://$3$4') + '\')')
+  reloadCode = reloadCode.replace('socketUrl.replace()', 'socketUrl.replace(/(^http(s?):\\/\\/)(.*:)(.*)/,' + (socketPortSpecified ? '\'ws$2://$3' + socketPortSpecified : '\'ws$2://$3$4') + '\')')
 
   expressApp.get(route, function (req, res) {
     res.type('text/javascript')


### PR DESCRIPTION
Should fix #126. @yamboy1 had the correct regex to append 80 if the browser didn't supply it, but `reload.js` also needed to be updated to correctly replace the new structure.