### PR TITLE
Fixed reload command line regression (Closes #133)

### DIFF
--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -1,10 +1,13 @@
 var http = require('http')
-var path = require('path')
 var reload = require('../lib/reload')
 var fs = require('fs')
 var open = require('open')
 var clc = require('cli-color')
 var argv = require('minimist')(process.argv.slice(2))
+
+var serveStatic = require('serve-static')
+var finalhandler = require('finalhandler')
+var URL = require('url-parse')
 
 var port = argv._[0]
 var dir = argv._[1]
@@ -23,25 +26,37 @@ var reloadOpts = {
 var time
 var reloadReturned
 
+var serve = serveStatic(dir, {'index': ['index.html', 'index.htm']})
+
 var server = http.createServer(function (req, res) {
-  var file
-  var reqUrl = req.url
+  var url = new URL(req.url)
+  var pathname = url.pathname.replace(/(\/)(.*)/, '$2') // Strip leading `/` so we can find files on file system
 
-  if (reqUrl === '/') {
-    file = path.join(dir, startPage)
-  } else {
-    file = path.join(dir, reqUrl) + '.html'
-  }
+  var fileEnding = pathname.split('.')[1]
 
-  appendReloadClientCode(file, function (contents) {
-    if (contents) {
-      res.writeHead(200, {'Content-Type': 'text/html; charset=UTF-8'})
-      res.end(contents)
-    } else {
-      res.writeHead(404, {'Content-Type': 'text/plain; charset=UTF-8'})
-      res.end('File Not Found')
+  if (fileEnding === 'html' || pathname === '/' || pathname === '') { // Server side inject reload code to html files
+    if (pathname === '/' || pathname === '') {
+      pathname = startPage
     }
-  })
+
+    fs.readFile(pathname, 'utf8', function (err, contents) {
+      if (err) {
+        res.writeHead(404, {'Content-Type': 'text/plain'})
+        res.end('File Not Found')
+      } else {
+        contents += '\n\n<!-- Inserted by Reload -->\n<script src="/reload/reload.js"></script>\n<!-- End Reload -->\n'
+
+        res.setHeader('Content-Type', 'text/html')
+        res.end(contents)
+      }
+    })
+  } else if (pathname === 'reload/reload.js') { // Server reload-client.js file from injected script tag
+    res.setHeader('Content-Type', 'text/javascript')
+
+    res.end(reloadReturned.reloadClientCode())
+  } else { // Serve any other file using serve-static
+    serve(req, res, finalhandler(req, res))
+  }
 })
 
 // Reload call and configurations. Stub app as it isn't used here
@@ -60,17 +75,3 @@ server.listen(port, function () {
     console.log(clc.green('Server restarted  at ' + time.toTimeString().slice(0, 8)))
   }
 })
-
-// Function to send reload-client code to the browser.
-function appendReloadClientCode (file, next) {
-  fs.readFile(file, 'utf8', function (err, contents) {
-    if (err) {
-      next(null)
-    }
-    var reloadClientCode = reloadReturned.reloadClientCode()
-
-    contents += '\n\n<!-- Inserted by Reload -->\n<script>' + reloadClientCode + '</script>\n<!-- End Reload -->\n'
-
-    next(contents)
-  })
-}

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -24,6 +24,7 @@ module.exports = function reload (app, opts, server) {
   var socketPortSpecified
   var argumentZero = arguments[0]
   var reloadJsMatch
+  var reloadReturn
 
   opts = opts || {}
 
@@ -128,15 +129,10 @@ module.exports = function reload (app, opts, server) {
       }
     })
   }
-  // Return an object, right now it contains only a function reload. When this function is called it calls the `sendMessage` function with the message 'reload' which reloads all connected clients.
-  return {
+
+  reloadReturn = {
     'reload': function () {
       sendMessage('reload')
-    },
-    'reloadClientCode': function () {
-      if (server) {
-        return reloadCode
-      }
     },
     'startWebSocketServer': function () {
       if (webSocketServerWaitStart) {
@@ -144,4 +140,14 @@ module.exports = function reload (app, opts, server) {
       }
     }
   }
+
+  if (server) { // Private return API only used in command line version of reload
+    reloadReturn.reloadClientCode = function () {
+      if (server) {
+        return reloadCode
+      }
+    }
+  }
+
+  return reloadReturn
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reload",
-  "version": "2.0.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -253,10 +253,9 @@
       }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -312,6 +311,16 @@
         "rimraf": "2.6.1"
       }
     },
+    "depd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
     "doctrine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
@@ -321,6 +330,16 @@
         "esutils": "2.0.2",
         "isarray": "1.0.0"
       }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
     "error-ex": {
       "version": "1.3.1",
@@ -420,6 +439,11 @@
         "es6-symbol": "3.1.1"
       }
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -447,7 +471,7 @@
         "babel-code-frame": "6.22.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
-        "debug": "2.6.8",
+        "debug": "2.6.7",
         "doctrine": "2.0.0",
         "escope": "3.6.0",
         "espree": "3.4.3",
@@ -462,7 +486,7 @@
         "inquirer": "0.12.0",
         "is-my-json-valid": "2.16.0",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.0",
+        "js-yaml": "3.9.1",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -499,7 +523,7 @@
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.7",
         "object-assign": "4.1.1",
         "resolve": "1.4.0"
       }
@@ -512,6 +536,17 @@
       "requires": {
         "debug": "2.6.8",
         "pkg-dir": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-import": {
@@ -522,7 +557,7 @@
       "requires": {
         "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
-        "debug": "2.6.8",
+        "debug": "2.6.7",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.2.3",
         "eslint-module-utils": "2.1.1",
@@ -641,6 +676,11 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+    },
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -682,6 +722,20 @@
         "object-assign": "4.1.1"
       }
     },
+    "finalhandler": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
+      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
+      "requires": {
+        "debug": "2.6.7",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      }
+    },
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -715,6 +769,11 @@
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
+    },
+    "fresh": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -812,6 +871,24 @@
         "ansi-regex": "2.1.1"
       }
     },
+    "http-errors": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
+      "requires": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+        }
+      }
+    },
     "ignore": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
@@ -837,8 +914,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "0.12.0",
@@ -978,9 +1054,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-      "integrity": "sha512-0LoUNELX4S+iofCT8f4uEHIiRBR+c2AINyC8qRWfC6QNruLtxVZRJaPcu/xwMgFIgDxF25tGHaDjvxzJCNE9yw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -1089,6 +1165,11 @@
         "timers-ext": "0.1.2"
       }
     },
+    "mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1123,8 +1204,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -1170,6 +1250,14 @@
         "define-properties": "1.1.2",
         "function-bind": "1.1.0",
         "object-keys": "1.0.11"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
       }
     },
     "once": {
@@ -1235,6 +1323,11 @@
       "requires": {
         "error-ex": "1.3.1"
       }
+    },
+    "parseurl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
     },
     "path-exists": {
       "version": "2.1.0",
@@ -1358,6 +1451,16 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
+    "querystringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+      "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
@@ -1410,6 +1513,11 @@
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
       }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.4.0",
@@ -1477,6 +1585,42 @@
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
       "dev": true
     },
+    "send": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
+      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
+      "requires": {
+        "debug": "2.6.7",
+        "depd": "1.1.1",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "1.6.1",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      }
+    },
+    "serve-static": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
+      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.1",
+        "send": "0.15.3"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+    },
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
@@ -1528,6 +1672,11 @@
         "minimist": "1.2.0",
         "pkg-conf": "2.0.0"
       }
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
     "string_decoder": {
       "version": "1.0.3",
@@ -1688,6 +1837,20 @@
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "url-parse": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+      "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+      "requires": {
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
+      }
     },
     "user-home": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "cli-color": "~1.2.0",
     "open": "~0.0.5",
     "ws": "~3.0.0",
-    "minimist": "~1.2.0"
+    "minimist": "~1.2.0",
+    "url-parse": "~1.1.9",
+    "serve-static": "~1.12.3",
+    "finalhandler": "~1.0.3"
   },
   "devDependencies": {
     "standard": "^10.0.2"


### PR DESCRIPTION
* Added mime as a dependency
* Handle all types of files statically
* Inject reload script tag on HTML files only
* Created public/private return API so that `reloadClientCode` (among other things later on need be) could be hidden from the public return API

(Closes #133)