### PR TITLE
Add optional --fallback CLI option

### DIFF
--- a/bin/reload
+++ b/bin/reload
@@ -14,6 +14,7 @@ program.version(require('../package.json').version)
   .option('-e, --exts [extensions]', 'Extensions separated by commas or pipes. Defaults to html,js,css.', 'html|js|css')
   .option('-p, --port [port]', 'The port to bind to. Can be set with PORT env variable as well. Defaults to 8080', '8080')
   .option('-s, --start-page [start-page]', 'Specify a start page. Defaults to index.html', 'index.html')
+  .option('-f, --fallback [fallback]', 'Fallback to start page when route is not found.')
   .option('-v, --verbose [verbose]', 'Turning on logging on the server and client side. Defaults to false', false)
   .parse(process.argv)
 
@@ -29,7 +30,7 @@ if (typeof program.watchDir === 'undefined') {
   program.watchDir = program.dir
 }
 
-var args = ['-e', program.exts, '-w', program.watchDir, '-q', '--', serverFile, program.port, program.dir, !!program.browser, program.hostname, runFile, program.startPage, program.verbose]
+var args = ['-e', program.exts, '-w', program.watchDir, '-q', '--', serverFile, program.port, program.dir, !!program.browser, program.hostname, runFile, program.startPage, program.fallback, program.verbose]
 supervisor.run(args)
 
 console.log('\nReload web server:')

--- a/bin/reload
+++ b/bin/reload
@@ -14,7 +14,7 @@ program.version(require('../package.json').version)
   .option('-e, --exts [extensions]', 'Extensions separated by commas or pipes. Defaults to html,js,css.', 'html|js|css')
   .option('-p, --port [port]', 'The port to bind to. Can be set with PORT env variable as well. Defaults to 8080', '8080')
   .option('-s, --start-page [start-page]', 'Specify a start page. Defaults to index.html', 'index.html')
-  .option('-f, --fallback [fallback]', 'Fallback to start page when route is not found.')
+  .option('-f, --fallback [fallback]', 'Fallback to the start page when route is not found')
   .option('-v, --verbose [verbose]', 'Turning on logging on the server and client side. Defaults to false', false)
   .parse(process.argv)
 

--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -34,12 +34,17 @@ var server = http.createServer(function (req, res) {
   var pathname = url.pathname.replace(/(\/)(.*)/, '$2') // Strip leading `/` so we can find files on file system
 
   var fileEnding = pathname.split('.')[1]
-  var noFileExt = pathname.indexOf('.') === -1
-  var shouldFallback = fallback && noFileExt
+  var noFileEnding = fileEnding === undefined
 
-  if (fileEnding === 'html' || pathname === '/' || pathname === '' || shouldFallback) { // Server side inject reload code to html files
-    if (pathname === '/' || pathname === '' || shouldFallback) {
+  if (fileEnding === 'html' || pathname === '/' || pathname === '' || noFileEnding) { // Server side inject reload code to html files
+    if (pathname === '/' || pathname === '') {
       pathname = dir + '/' + startPage
+    } else if (noFileEnding) {
+      if (fs.existsSync(dir + '/' + pathname + '.html')) {
+        pathname = dir + '/' + pathname + '.html'
+      } else if (fallback) {
+        pathname = dir + '/' + startPage
+      }
     } else {
       pathname = dir + '/' + pathname
     }

--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -15,7 +15,8 @@ var openBrowser = (argv._[2] === 'true')
 var hostname = argv._[3]
 var runFile = argv._[4]
 var startPage = argv._[5]
-var verbose = (argv._[6] === 'true')
+var fallback = (argv._[6] === 'true')
+var verbose = (argv._[7] === 'true')
 
 var reloadOpts = {
   port: port,
@@ -33,9 +34,11 @@ var server = http.createServer(function (req, res) {
   var pathname = url.pathname.replace(/(\/)(.*)/, '$2') // Strip leading `/` so we can find files on file system
 
   var fileEnding = pathname.split('.')[1]
+  var noFileExt = pathname.indexOf('.') === -1
+  var shouldFallback = fallback && noFileExt
 
-  if (fileEnding === 'html' || pathname === '/' || pathname === '') { // Server side inject reload code to html files
-    if (pathname === '/' || pathname === '') {
+  if (fileEnding === 'html' || pathname === '/' || pathname === '' || shouldFallback) { // Server side inject reload code to html files
+    if (pathname === '/' || pathname === '' || shouldFallback) {
       pathname = dir + '/' + startPage
     } else {
       pathname = dir + '/' + pathname


### PR DESCRIPTION
Closes #164 and #166. Introduces an opt-in `-f` or `--fallback` command-line flag, which allows to serve up the start page as a fallback, when the requested route cannot be resolved. This is useful when developing a single-page app that handles routing client-side with HTML5 history API.

Currently, non-resolvable routes such as `/about` or `/blog/some-post` are falling through `serve-static`, which can't match them to a file, and thus returns a `404`. When `-f` flag is on, `reload` will detect these routes, and respond with `index.html` (or custom start page when `-s` is provided). The front-end (e.g. `react` using `react-router-dom`) can then take over the rendering based on the URL path.

As a stretch goal we could also serve up `blog.html` in response to `/blog` if the said file happens to exist.

Inspired by [`--history-api-fallback`](https://webpack.js.org/configuration/dev-server/#devserver-historyapifallback) in `webpack-dev-server`.