### PR TITLE
3.0.3 / 2019-10-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+3.0.3 / 2019-10-20
+------------------
+
+* Updated cli-color from ~1.4.0 to ~2.0.0 - See: https://github.com/alallier/reload/pull/212
+* Updated open from ^6.1.0 to ^7.0.0 - See: https://github.com/alallier/reload/pull/213
+* Updated mocha from 6.2.1 to 6.2.2 - See: https://github.com/alallier/reload/pull/214
+* Updated ws from ~7.1.0 to ~7.2.0 - See: https://github.com/alallier/reload/pull/215
+
 3.0.2 / 2019-10-06
 ------------------
 

--- a/expressSampleApp/package.json
+++ b/expressSampleApp/package.json
@@ -9,7 +9,7 @@
     "express": "4.17.1",
     "body-parser": "1.19.0",
     "morgan": "1.9.1",
-    "reload": "3.0.2",
+    "reload": "3.0.3",
     "supervisor": "0.12.0"
   },
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reload",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reload",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "files": [
     "bin",
     "lib",


### PR DESCRIPTION
* Updated cli-color from ~1.4.0 to ~2.0.0 - See: https://github.com/alallier/reload/pull/212
* Updated open from ^6.1.0 to ^7.0.0 - See: https://github.com/alallier/reload/pull/213
* Updated mocha from 6.2.1 to 6.2.2 - See: https://github.com/alallier/reload/pull/214
* Updated ws from ~7.1.0 to ~7.2.0 - See: https://github.com/alallier/reload/pull/215