### PR TITLE
Fix command line Reload in Node 14. Invalid argument error when writing temp file

### DIFF
--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -72,8 +72,9 @@ var server = http.createServer(function (req, res) {
 reload(function () {}, reloadOpts, server).then(function (reload) {
   reloadReturned = reload
   server.listen(port, function () {
+    // Reload writes a random temp file which is checked on a reload so that the browser is not opened every time a change is made
     if (!fs.existsSync(runFile)) {
-      fs.writeFileSync(runFile)
+      fs.writeFileSync(runFile, '')
 
       // If openBrowser, open the browser with the given start page above, at a hostname (localhost default or specified).
       if (openBrowser) {


### PR DESCRIPTION
Fixed invalid argument error that cropped up in Node 14 when Reload was writing the temp file on the command line side of Reload. Now Reload writes empty string to the file.

Closes #241 