### PR TITLE
Trigger CI on PRs too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 name: CI
 jobs:
   test:


### PR DESCRIPTION
An omission from the original ci.yml can prevent some pull requests from triggering CI.