### PR TITLE
Add option to provide add-on script to append to reload code

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Options:
   -s, --start-page [start-page]  Specify a start page. Defaults to index.html
   -f, --fallback [fallback]      Fallback to the start page when route is not found
   -v, --verbose [verbose]        Turning on logging on the server and client side. Defaults to false
+  -a, --addon [file]             Add-on script file path
 
 ```
 

--- a/bin/reload
+++ b/bin/reload
@@ -16,6 +16,7 @@ program.version(require('../package.json').version)
   .option('-s, --start-page [start-page]', 'Specify a start page. Defaults to index.html', 'index.html')
   .option('-f, --fallback [fallback]', 'Fallback to the start page when route is not found')
   .option('-v, --verbose [verbose]', 'Turning on logging on the server and client side. Defaults to false', false)
+  .option('-a, --addon [file]', 'Add-on script file path')
   .parse(process.argv)
 
 const options = program.opts()
@@ -32,7 +33,7 @@ if (typeof options.watchDir === 'undefined') {
   options.watchDir = options.dir
 }
 
-const args = ['-e', options.exts, '-w', options.watchDir, '-q', '--', serverFile, options.port, options.dir, !!options.browser, options.hostname, runFile, options.startPage, options.fallback, options.verbose]
+const args = ['-e', options.exts, '-w', options.watchDir, '-q', '--', serverFile, options.port, options.dir, !!options.browser, options.hostname, runFile, options.startPage, options.fallback, options.verbose, options.addon]
 supervisor.run(args)
 
 console.log('\nReload web server:')

--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -16,10 +16,12 @@ const runFile = argv._[4]
 const startPage = argv._[5]
 const fallback = (argv._[6] === 'true')
 const verbose = (argv._[7] === 'true')
+const addon = (argv._[8] === 'undefined' ? undefined : argv._[8])
 
 const reloadOpts = {
   verbose,
-  noExpress: true
+  noExpress: true,
+  addon
 }
 
 let time

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -18,11 +18,13 @@ module.exports = function reload (app, opts, server) {
     const forceWss = opts.forceWss || false
     const verboseLogging = opts.verbose || false
     const webSocketServerWaitStart = opts.webSocketServerWaitStart || false
+    const ADDON_FILE = opts.addon || null
 
     // Application variables
     const RELOAD_FILE = path.join(__dirname, './reload-client.js')
     let reloadCode = fs.readFileSync(RELOAD_FILE, 'utf8')
     const route = opts.route ? processRoute(opts.route) : '/reload/reload.js'
+    let addonCode = ''
 
     // Websocket server variables
     let wss
@@ -54,6 +56,14 @@ module.exports = function reload (app, opts, server) {
 
     if (typeof webSocketServerWaitStart !== 'boolean') {
       return reject(new Error('webSocketServerWaitStart option specified is not of type boolean'))
+    }
+
+    if (ADDON_FILE) {
+      try {
+        addonCode = fs.readFileSync(ADDON_FILE, 'utf8')
+      } catch (err) {
+        reject(new Error('Unable to open the add-on file: ' + ADDON_FILE))
+      }
     }
 
     // Application setup
@@ -99,6 +109,10 @@ module.exports = function reload (app, opts, server) {
       const webSocketString = forceWss ? 'wss://$3' : 'ws$2://$3'
 
       reloadCode = reloadCode.replace('socketUrl.replace()', 'socketUrl.replace(/(^http(s?):\\/\\/)(.*:)(.*)/,' + (socketPortSpecified ? '\'' + webSocketString + socketPortSpecified : '\'' + webSocketString + '$4') + '\')')
+
+      if (addonCode) {
+        reloadCode += '\n\n// Add-on code\n' + addonCode
+      }
     }
 
     // Websocket server setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reload",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reload",
-      "version": "3.2.0",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "cli-color": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reload",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "files": [
     "bin",
     "lib",

--- a/test/api/reload-addon.js
+++ b/test/api/reload-addon.js
@@ -1,0 +1,1 @@
+console.log('addon code')


### PR DESCRIPTION
The PR adds an option to provide extra script to further customize the client script (that is appended at the end of served HTML page).

For example, to view logs we want to scroll to bottom every time the page reloads. Following JavaScript can be appended to the reload script:
```js
// FILE: reload-addon.js
// scroll to bottom on load
window.addEventListener('load', () => {
  window.setTimeout(()=>window.scrollTo(0, document.body.scrollHeight), 50);
});
```

To tell reload server about the extra script to append use option `-a`:
```bash
reload -d "/sensor/logs/" -a "/home/user/bin/reload-addon.js"
```

This will make reload server provide following reload.js:
```js
// default reload.js code
...
})()


// Add-on code
// FILE: reload-addon.js
// scroll to bottom on load
window.addEventListener('load', () => {
  window.setTimeout(()=>window.scrollTo(0, document.body.scrollHeight), 50);
});
```

Using this, depending on the application requirements, custom features (like floating menus, highlighting, scrolling etc) can be added to the served pages.