### PR TITLE
Fix command line bug around reload.js injection

### DIFF
--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -45,13 +45,13 @@ const server = http.createServer(function (req, res) {
   const file = path.join(dir, pathname)
 
   // reload script
-  if (pathname === 'reload/reload.js') {
+  if (pathname === '/reload/reload.js') {
     res.writeHead(200, { 'Content-Type': 'text/javascript' })
     return res.end(reloadReturned.reloadClientCode())
   }
 
-  // static assets
-  if (ext !== '.html' && ext !== '.htm' && fs.existsSync(file)) {
+  // static assets, not a .html or .htm or empty extension when auto serving `/` to index.html
+  if (ext !== '.html' && ext !== '.htm' && ext !== '' && fs.existsSync(file)) {
     return serve(req, res, finalhandler(req, res))
   }
 


### PR DESCRIPTION
Fix bug on command line side of reload where reload.js file wasn't being served and index.html auto serving from `/` not having the injected script tag for reload.js file

Fixed bug created by #326 