### PR TITLE
Add `forceWs` param

### DIFF
--- a/lib/reload.js
+++ b/lib/reload.js
@@ -15,6 +15,7 @@ module.exports = function reload (app, opts, server) {
     const port = opts.port || 9856
     const httpsOption = opts.https || null
     const httpServerOrPort = server || port
+    const forceWs = opts.forceWs || false
     const forceWss = opts.forceWss || false
     const verboseLogging = opts.verbose || false
     const webSocketServerWaitStart = opts.webSocketServerWaitStart || false
@@ -42,6 +43,10 @@ module.exports = function reload (app, opts, server) {
 
     if (typeof port !== 'number') {
       return reject(new Error('Specified port is not of type number'))
+    }
+
+    if (typeof forceWs !== 'boolean') {
+      return reject(new Error('forceWs option specified is not of type boolean'))
     }
 
     if (typeof forceWss !== 'boolean') {
@@ -96,7 +101,8 @@ module.exports = function reload (app, opts, server) {
         reloadCode = reloadCode.replace('verboseLogging = false', 'verboseLogging = true')
       }
 
-      const webSocketString = forceWss ? 'wss://$3' : 'ws$2://$3'
+      let webSocketString = forceWss ? 'wss://$3' : 'ws$2://$3'
+      if (forceWs) webSocketString = 'ws://$3'
 
       reloadCode = reloadCode.replace('socketUrl.replace()', 'socketUrl.replace(/(^http(s?):\\/\\/)(.*:)(.*)/,' + (socketPortSpecified ? '\'' + webSocketString + socketPortSpecified : '\'' + webSocketString + '$4') + '\')')
     }

--- a/test/api/api.js
+++ b/test/api/api.js
@@ -302,6 +302,33 @@ describe('API', function () {
     })
   })
 
+  it('Should force ws on client with forceWs set to true', async () => {
+    const app = express()
+
+    let reloadReturned
+    try {
+      reloadReturned = await reload(app, { forceWs: true })
+    } catch (err) {
+
+    }
+
+    const response = await helperFunction.makeRequest('/reload/reload.js', app)
+
+    let reloadClientCode
+
+    response.on('data', function (chunk) {
+      reloadClientCode = chunk
+    })
+
+    response.on('end', function () {
+      const testRegex = /ws:\/\//gm
+
+      assert(testRegex.test(reloadClientCode))
+
+      helperFunction.closeReloadSocket(reloadReturned)
+    })
+  })
+
   it('Should error if force wss option is not a boolean', async () => {
     const app = express()
 
@@ -310,6 +337,17 @@ describe('API', function () {
       assert.fail('Not supposed to pass')
     } catch (err) {
       assert.strictEqual(err.message, 'forceWss option specified is not of type boolean')
+    }
+  })
+
+  it('Should error if force ws option is not a boolean', async () => {
+    const app = express()
+
+    try {
+      await reload(app, { forceWs: 'true' })
+      assert.fail('Not supposed to pass')
+    } catch (err) {
+      assert.strictEqual(err.message, 'forceWs option specified is not of type boolean')
     }
   })
 })


### PR DESCRIPTION
This fixes a bug with Firefox in HTTPS self-signed situations.

If you use reload in that scenario, it will force you to use `wss` in which case Firefox will throw `NS_ERROR_GENERATE_FAILURE(NS_ERROR_MODULE_SECURITY, MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT)` errors.

With this new param, you can optionally force reload to run with `ws` instead of `wss` to prevent this problem.